### PR TITLE
fix: resnet_bpda baseline not set to eval mode

### DIFF
--- a/eval_sde_adv_bpda.py
+++ b/eval_sde_adv_bpda.py
@@ -128,7 +128,7 @@ def eval_bpda(args, config, model, x_val, y_val, adv_batch_size, log_dir):
 
     # ------------------ apply the attack to resnet ------------------
     print(f'apply the bpda attack to resnet...')
-    resnet_bpda = ResNet_Adv_Model(args, config)
+    resnet_bpda = ResNet_Adv_Model(args, config).eval()
     if ngpus > 1:
         resnet_bpda = torch.nn.DataParallel(resnet_bpda)
 


### PR DESCRIPTION
### Problem
fix: resnet_bpda baseline not set to eval mode

### Fix
Replace:
```
    resnet_bpda = ResNet_Adv_Model(args, config)
    if ngpus > 1:
        resnet_bpda = torch.nn.DataParallel(resnet_bpda)

    start_time = time.time()
    init_acc = get_accuracy(resnet_bpda, x_val, y_val, bs=adv_batch_size)
```

with:
```
    resnet_bpda = ResNet_Adv_Model(args, config).eval()
    if ngpus > 1:
        resnet_bpda = torch.nn.DataParallel(resnet_bpda)

    start_time = time.time()
    init_acc = get_accuracy(resnet_bpda, x_val, y_val, bs=adv_batch_size)
```

### Files changed
- `eval_sde_adv_bpda.py`